### PR TITLE
Commenting jaxb force rebuild: causes endless-build loop in Eclipse.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
 							<bindingIncludes>
 								<include>SPHSchema.xjb</include>
 							</bindingIncludes>
-							<forceRegenerate>true</forceRegenerate>
+							<!--<forceRegenerate>true</forceRegenerate>-->
 							<schemaDirectory>src/main/resources/schema</schemaDirectory>
 							<generateDirectory>${project.build.directory}/generated-sources/SPH</generateDirectory>
 							<schemaIncludes>


### PR DESCRIPTION
@tarelli check if it works for you (same change as in core)